### PR TITLE
Rearrange Pie shapes list and add separators to better reading

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -2102,9 +2102,19 @@ def pieMenuStart():
 
         comboShape.blockSignals(True)
         comboShape.clear()
-        available_shape = [ "Pie", "RainbowUp", "RainbowDown", "UpDown", "TableTop",\
-                           "TableDown", "LeftRight" ]
-        comboShape.addItems(available_shape)
+        comboShape.addItem("Pie")
+        comboShape.addItem(" ") # Add separator
+        comboShape.model().item(comboShape.count()-1).setEnabled(False)  # Disable the separator item
+        comboShape.addItem("RainbowUp")
+        comboShape.addItem("RainbowDown")
+        comboShape.addItem(" ") # Add separator
+        comboShape.model().item(comboShape.count()-1).setEnabled(False)  # Disable the separator item   
+        comboShape.addItem("UpDown")
+        comboShape.addItem("LeftRight")
+        comboShape.addItem(" ") # Add separator
+        comboShape.model().item(comboShape.count()-1).setEnabled(False)  # Disable the separator item
+        comboShape.addItem("TableTop")
+        comboShape.addItem("TableDown")
         index = comboShape.findText(shape)
         if index != -1:
             comboShape.setCurrentIndex(index)


### PR DESCRIPTION
Self explanatory:

<img width="454" alt="Screenshot 2024-01-30 at 14 55 35" src="https://github.com/Grubuntu/PieMenu/assets/5942369/7cacfff4-20fa-4b6a-aab3-af7e24244f5f">
