### PR TITLE
Added the option to show command names with LeftRight pie shape

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -822,7 +822,7 @@ def pieMenuStart():
                 self.menu.setMinimumHeight(self.menuSize)
 
             displayCommandName = False
-            if shape == "Pie":
+            if shape in ["Pie", "LeftRight"]:
                 try: # get displayCommandName to display or not command name only for Pie shape
                     displayCommandName = getdisplayCommandName(keyValue)
                 except:
@@ -864,6 +864,45 @@ def pieMenuStart():
                         iconLabel.setObjectName("iconLabel")
                         iconLabel.setPixmap(iconButton.pixmap(QtCore.QSize(icon, icon)))
                         iconLabel.setStyleSheet(styleCurrentTheme)
+                        layout.addWidget(iconLabel)
+
+                    # modify style for display command name (only with LeftRight shape)
+                    if displayCommandName and shape == "LeftRight":
+                        num_per_row = math.ceil(commandNumber/2)
+                        button.setIcon(QtGui.QIcon())
+                        # set padding and font size dependind on icon size
+                        font_size = round(icon/2)
+                        if ((num-1) < (num_per_row)):
+                            # Left side icons
+                            padding = "QToolButton#pieMenu {padding-right: " + str(icon) \
+                            + "px; font-size: " + str(font_size) + "px;}"
+                        else:
+                            # Right side icons
+                            padding = "QToolButton#pieMenu {padding-left: " + str(icon) \
+                            + "px; font-size: " + str(font_size) + "px;}"
+                        button.setStyleSheet(styleCurrentTheme + radius + padding)
+                        # get length of the string
+                        text_length = QFontMetrics(button.font()).horizontalAdvance(
+                            commands[commands.index(i)].text())
+                    
+                        button.setGeometry(buttonSize, 0,  2 * buttonSize + text_length, buttonSize)
+                        # layout for icon and command string
+                        layout = QtGui.QHBoxLayout(button)
+                        layout.setContentsMargins((icon/4), 0, 0, 0)
+                        if ((num-1) < (num_per_row)):
+                            # Left side icons: align icon to the right and add some margin  
+                            layout.addStretch(1)
+                            iconMarging = "#iconLabel {margin-right: " + str(icon/4) + "px;}"
+                        iconButton = QtGui.QIcon(commands[commands.index(i)].icon())
+                        iconLabel = QtGui.QLabel()
+                        iconLabel.setObjectName("iconLabel")
+                        iconLabel.setPixmap(iconButton.pixmap(QtCore.QSize(icon, icon)))
+                        if ((num-1) < (num_per_row)):
+                            # Left side icons
+                            iconLabel.setStyleSheet(styleCurrentTheme + iconMarging)
+                        else:
+                            # Right side icons
+                            iconLabel.setStyleSheet(styleCurrentTheme)
                         layout.addWidget(iconLabel)
 
                     if shape == "TableTop":
@@ -914,17 +953,33 @@ def pieMenuStart():
 
 
                     elif shape == "LeftRight":
-                        ### Table Left and Right  ###
-                        num_per_row = math.ceil(commandNumber/2)
-                        Y = ((num -1) % num_per_row) * (buttonSize + icon_spacing)
-                        if ((num-1) < (num_per_row)) :
-                            offset = 0
-                        else :
-                            offset = 2*self.radius
-                        X = (self.radius - offset )
+                        ### Left and Right with command names ###
+                        if displayCommandName:
+                            num_per_row = math.ceil(commandNumber/2)
+                            Y = ((num -1) % num_per_row) * (buttonSize + icon_spacing)  
+                            if ((num-1) < (num_per_row)) :
+                                # Left side icons
+                                offset = - text_length
+                            else :
+                                # Right side icons
+                                offset = 2 * self.radius
+                            X = ( self.radius - offset - text_length/2  ) # TODO: align them to the left
 
-                        button.setProperty("ButtonX", -X)
-                        button.setProperty("ButtonY", Y - ((num_per_row - 1) * (buttonSize + icon_spacing)) / 2)
+                            button.setProperty("ButtonX", -X )
+                            button.setProperty("ButtonY", Y - ((num_per_row - 1) * (buttonSize + icon_spacing)  ) / 2)
+                            
+                        else:
+                            ### Left and Right  ###
+                            num_per_row = math.ceil(commandNumber/2)
+                            Y = ((num -1) % num_per_row) * (buttonSize + icon_spacing)  
+                            if ((num-1) < (num_per_row)) :
+                                offset = 0
+                            else :
+                                offset = 2*self.radius
+                            X = (self.radius - offset )
+
+                            button.setProperty("ButtonX", -X)
+                            button.setProperty("ButtonY", Y - ((num_per_row - 1) * (buttonSize + icon_spacing)  ) / 2)
                     else :
                         ### Pie / RainbowUp / RainbowDown  ###
                         button.setProperty("ButtonX", self.radius *
@@ -2109,7 +2164,7 @@ def pieMenuStart():
         else:
             labelNumColumn.setText("Number of rows:")
 
-        if shape == "Pie":
+        if shape in ["Pie", "LeftRight"]:
             labeldisplayCommandName.setVisible(True)
             cboxDisplayCommandName.setVisible(True)
             cboxDisplayCommandName.setEnabled(True)


### PR DESCRIPTION
Now LeftRight pie shape can show command names, the labels get aligned to left or right depending on the side:
<img width="661" alt="left-right" src="https://github.com/Grubuntu/PieMenu/assets/5942369/2a3043b9-2d26-43bf-9fbe-893effcc2397">

I hope you like it
;)