### PR TITLE
Support for Freecad Theme Accent Colors

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -72,9 +72,11 @@ def pieMenuStart():
     shortcutList =[]
 
     paramPath = "User parameter:BaseApp/PieMenu"
-    paramIndexPath= "User parameter:BaseApp/PieMenu/Index"
+    paramIndexPath = "User parameter:BaseApp/PieMenu/Index"
+    paramAccents = "User parameter:BaseApp/Preferences/Themes"
     paramGet = App.ParamGet(paramPath)
     paramIndexGet = App.ParamGet(paramIndexPath)
+    paramAccentsGet = App.ParamGet(paramAccents)
 
     ## HACK: workaround to avoid ghosting : we find wbs already loaded,
     ## so as not to reload them again in the function 'updateCommands'
@@ -91,6 +93,19 @@ def pieMenuStart():
         with open(stylesheet_path, "r") as f:
             styleCurrentTheme = f.read()
         styleCurrentTheme = styleCurrentTheme.replace("pieMenuQss:", stylepath)
+        # Get FreeCAD ThemeAccentColors
+        ThemeAccentColor1 = paramAccentsGet.GetUnsigned("ThemeAccentColor1")
+        ThemeAccentColor2 = paramAccentsGet.GetUnsigned("ThemeAccentColor2")
+        ThemeAccentColor3 = paramAccentsGet.GetUnsigned("ThemeAccentColor3")
+        ThemeAccentColor1_hex_full = format(ThemeAccentColor1, '06x')
+        ThemeAccentColor2_hex_full = format(ThemeAccentColor2, '06x')
+        ThemeAccentColor3_hex_full = format(ThemeAccentColor3, '06x')
+        ThemeAccentColor1_hex = ThemeAccentColor1_hex_full[:-2]
+        ThemeAccentColor2_hex = ThemeAccentColor2_hex_full[:-2]
+        ThemeAccentColor3_hex = ThemeAccentColor3_hex_full[:-2]
+        styleCurrentTheme = styleCurrentTheme.replace("@ThemeAccentColor1", "#" + str(ThemeAccentColor1_hex))
+        styleCurrentTheme = styleCurrentTheme.replace("@ThemeAccentColor2", "#" + str(ThemeAccentColor2_hex))
+        styleCurrentTheme = styleCurrentTheme.replace("@ThemeAccentColor3", "#" + str(ThemeAccentColor3_hex))
         return styleCurrentTheme
 
     styleCurrentTheme = getStyle()

--- a/InitGui.py
+++ b/InitGui.py
@@ -26,7 +26,7 @@
 # http://www.freecadweb.org/wiki/index.php?title=Code_snippets
 
 global PIE_MENU_VERSION
-PIE_MENU_VERSION = "1.3.8.1"
+PIE_MENU_VERSION = "1.3.8.2"
 
 def pieMenuStart():
     """Main function that starts the Pie Menu."""

--- a/Resources/Stylesheets/Accents.qss
+++ b/Resources/Stylesheets/Accents.qss
@@ -1,0 +1,147 @@
+/* PieMenu widget stylesheet for FreeCAD */
+/* Copyright (C) 2024 Pgilfernandez @ FreeCAD */
+
+
+/* ====================================================== */
+/*                 Normal pie button style                */
+/* ====================================================== */
+/* Default style applied to buttons */
+QToolButton#pieMenu::menu-indicator {
+    subcontrol-origin: padding;
+    subcontrol-position: center center;
+}
+
+QToolButton#pieMenu {
+    color: @ThemeAccentColor1; /* command names text color */
+    background-color: @ThemeAccentColor3;
+    border: 1px solid @ThemeAccentColor3;
+}
+
+QToolButton#pieMenu:disabled {
+    background-color: @ThemeAccentColor2;
+}
+
+QToolButton#pieMenu:hover {
+    color: @ThemeAccentColor3; /* command names text color */
+    background-color: @ThemeAccentColor1;
+    border-color: @ThemeAccentColor1;
+}
+
+/* When the button is checkeable and it's in "checked" state */
+QToolButton#pieMenu:checked {
+    background-color: @ThemeAccentColor3;
+    border: 3px solid @ThemeAccentColor1;
+}
+
+QToolButton#pieMenu:checked:hover {
+    background-color: @ThemeAccentColor1;
+    border-color: @ThemeAccentColor1;
+}
+
+
+/* ====================================================== */
+/*                 Close pie button style                 */
+/* ====================================================== */
+/* It is the ring that helps to visually locate the middle of the pie */
+QToolButton#styleMenuClose {
+    background-color: transparent;
+    border: 4px solid @ThemeAccentColor3;
+    image: none;
+}
+
+QToolButton#styleMenuClose:hover {
+    background-color: transparent;
+    image: none;
+}
+
+QToolButton#styleMenuClose::menu-indicator {
+    image: none;
+}
+
+
+/* ====================================================== */
+/*                      comboBox style                    */
+/* ====================================================== */
+/* Used for fillet/chamfer fast radius setting (and probably others) */
+
+QComboBox#styleCombo {
+    background-color: transparent;
+    border: 1px solid transparent;
+}
+
+QToolButton#styleComboValid,
+QToolButton#styleComboCancel {
+    background-color: transparent;
+    border-radius: 4px;
+}
+
+QToolButton#styleComboValid:hover,
+QToolButton#styleComboCancel:hover {
+    background-color: @ThemeAccentColor3;
+    border: 1px solid @ThemeAccentColor1;
+}
+
+QToolButton#styleComboValid {
+    image: url(pieMenuQss:images_dark-light/edit_OK.svg);
+}
+
+QToolButton#styleComboCancel {
+    image: url(pieMenuQss:images_dark-light/edit_Cancel.svg);
+}
+
+
+/* ====================================================== */
+/*                      Quick Menu                        */
+/* ====================================================== */
+QMenu#styleQuickMenu {
+    padding: 5px 10px 5px 10px;
+}
+
+QMenu#styleQuickMenuItem::item {
+    padding: 5px 20px 5px 20px;
+    text-align: left;
+}
+
+QToolButton#styleButtonMenu {
+    image: url(pieMenuQss:images_dark-light/PieMenuQuickMenuDark.svg);
+    background-color: transparent;
+}
+
+QToolButton#styleButtonMenu:hover {
+    image: url(pieMenuQss:images_dark-light/PieMenuQuickMenuLightHover.svg);
+    background-color: @ThemeAccentColor1; /* necessary for overriding QToolButton stylesheets */
+}
+
+QToolButton#styleButtonMenu::menu-indicator {
+    image: none;
+}
+
+
+/* ====================================================== */
+/*                     Other styles                       */
+/* ====================================================== */
+QMenu#styleContainer {
+    background-color: transparent; /* Important, do not change */
+}
+
+QFrame#separatorPieMenu,
+QFrame#separatorSettings {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px solid transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Important fix to override QLabel styling from FreeCAD stylesheets, do not remove */
+QLabel#iconLabel {
+    background-color: transparent;
+}
+
+
+/* ====================================================== */
+/*                     CheckBox style                     */
+/* ====================================================== */
+
+QCheckBox#styleCheckbox {
+    margin-left: 10px;
+}
+


### PR DESCRIPTION
There is probably room for improvement but it was pretty straightforward.

The usage is simple, in the stylesheet change a color value for `@ThemeAccentColor1`, `@ThemeAccentColor2` or `@ThemeAccentColor3` and done.

BTW, I will need more time to adapt the stylesheets to this new feature so, if you don't mind, you can merge the dev 1.3.9 with the commandNames pie feature.