### PR TITLE
Set a default stylesheet if stored theme doesn't exist

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -88,6 +88,8 @@ def pieMenuStart():
         if theme == "":
             theme = "Legacy" # default theme if new installation
         stylesheet_path = f"{stylepath}{theme}.qss"
+        if not os.path.exists(stylesheet_path):
+            stylesheet_path = f"{stylepath}Legacy.qss" 
         with open(stylesheet_path, "r") as f:
             styleCurrentTheme = f.read()
         styleCurrentTheme = styleCurrentTheme.replace("pieMenuQss:", stylepath)

--- a/InitGui.py
+++ b/InitGui.py
@@ -89,7 +89,8 @@ def pieMenuStart():
             theme = "Legacy" # default theme if new installation
         stylesheet_path = f"{stylepath}{theme}.qss"
         if not os.path.exists(stylesheet_path):
-            stylesheet_path = f"{stylepath}Legacy.qss" 
+            stylesheet_path = f"{stylepath}Legacy.qss"
+            paramGet.SetString("Theme", "Legacy")
         with open(stylesheet_path, "r") as f:
             styleCurrentTheme = f.read()
         styleCurrentTheme = styleCurrentTheme.replace("pieMenuQss:", stylepath)


### PR DESCRIPTION
This happens when designing stylesheets but it could help normal users that break something if they start tinkering with style.

I added a simple rule to check if the stylesheet file exists, if not it sets Legacy.qss as actual theme. 