### PR TITLE
Reduce the distance of buttons from the center to the half

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -961,7 +961,7 @@ def pieMenuStart():
                     elif shape == "TableLeft":
                         ### Table Left  ###
                         num_of_line = math.ceil(commandNumber/num_per_row)
-                        X = - buttonSize - self.radius -((num-1) // num_per_row) * (buttonSize + icon_spacing)
+                        X = - buttonSize - self.radius / 2 -((num-1) // num_per_row) * (buttonSize + icon_spacing)
                         Y = ((num-1) % num_per_row) * (buttonSize + icon_spacing)
                         button.setProperty("ButtonX", X )
                         button.setProperty("ButtonY", Y - ((num_per_row-1) * (buttonSize + icon_spacing)) / 2)
@@ -969,7 +969,7 @@ def pieMenuStart():
                     elif shape == "TableRight":
                         ### Table Right  ###
                         num_of_line = math.ceil(commandNumber/num_per_row)
-                        X = buttonSize + self.radius + ((num-1) // num_per_row) * (buttonSize + icon_spacing)
+                        X = buttonSize + self.radius / 2 + ((num-1) // num_per_row) * (buttonSize + icon_spacing)
                         Y = ((num-1) % num_per_row) * (buttonSize + icon_spacing)
                         button.setProperty("ButtonX", X )
                         button.setProperty("ButtonY", Y - ((num_per_row-1) * (buttonSize + icon_spacing)) / 2)


### PR DESCRIPTION
For shapes "TableLeft" and "TableRight".

It was too much compared with other pie shapes:

<img width="503" alt="pie" src="https://github.com/Grubuntu/PieMenu/assets/5942369/7d5dce89-6f98-47ac-be48-49e0837451d0">
