### PR TITLE
Update translation script to have maintainer workflow

### DIFF
--- a/Resources/translation/PieMenu.ts
+++ b/Resources/translation/PieMenu.ts
@@ -1,0 +1,381 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>AccesoriesMenu</name>
+    <message>
+        <location filename="../../InitGui.py" line="267"/>
+        <source>Pie menu settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Commands</name>
+    <message>
+        <location filename="../../InitGui.py" line="3071"/>
+        <source>Move selected command up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3089"/>
+        <source>Move selected command down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3095"/>
+        <source>Add separator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3178"/>
+        <source>Remove selected command</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ContextTab</name>
+    <message>
+        <location filename="../../InitGui.py" line="3196"/>
+        <source>Vertex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3197"/>
+        <source>Set desired operator and vertex number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3201"/>
+        <source>Edge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3202"/>
+        <source>Set desired operator and edge number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3206"/>
+        <source>Face</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3207"/>
+        <source>Set desired operator and face number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3211"/>
+        <source>Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3212"/>
+        <source>Set desired operator and object number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3269"/>
+        <source>Enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3334"/>
+        <source>Reset to defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3919"/>
+        <source>Context</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Fast Spinbox</name>
+    <message>
+        <location filename="../../InitGui.py" line="726"/>
+        <source>Through all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="734"/>
+        <source>Reversed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="742"/>
+        <source>Symmetric to plane</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FreeCAD Menu</name>
+    <message>
+        <location filename="../../InitGui.py" line="281"/>
+        <source>Accessories</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GlobalSettingsTab</name>
+    <message>
+        <location filename="../../InitGui.py" line="2087"/>
+        <source>For TAB press CTRL+TAB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2088"/>
+        <source>Global shortcut behavior: Toggle show/hide PieMenu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2120"/>
+        <source>Global shortcut: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2531"/>
+        <source>Hover delay (ms):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2547"/>
+        <source>Press</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2548"/>
+        <source>Hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3680"/>
+        <source>Assign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3740"/>
+        <source>Show QuickMenu:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3755"/>
+        <source>Theme style:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3770"/>
+        <source>Trigger mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3813"/>
+        <source>Shortcut deleted ! No shortcut assigned </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3821"/>
+        <source>Invalid shortcut ! Current global shortcut : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3827"/>
+        <source>New global shortcut assigned: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3835"/>
+        <source>Global shortcut : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3877"/>
+        <source>Global context:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3920"/>
+        <source>Global settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../InitGui.py" line="3974"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3979"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PieMenuTab</name>
+    <message>
+        <location filename="../../InitGui.py" line="3673"/>
+        <location filename="../../InitGui.py" line="2119"/>
+        <source>Current shortcut: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2146"/>
+        <source>Add new pie menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2151"/>
+        <source>Please insert menu name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2152"/>
+        <source>Menu already exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2223"/>
+        <source>New menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2237"/>
+        <source>Remove current pie menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2297"/>
+        <source>Rename current pie menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2304"/>
+        <source>Rename menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2337"/>
+        <source>Copy current pie menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2386"/>
+        <source>Copy menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2437"/>
+        <source>Workbench associated to this PieMenu:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2525"/>
+        <source>Pie size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2537"/>
+        <source>Shape:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2540"/>
+        <source>Show command names:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2675"/>
+        <location filename="../../InitGui.py" line="2585"/>
+        <source>Number of columns:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2587"/>
+        <source>Number of rows:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2680"/>
+        <source>Icon spacing:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2685"/>
+        <source>Command per circle:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2831"/>
+        <source>Button size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3656"/>
+        <source>Shortcut deleted! No shortcut assigned </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3663"/>
+        <source>Invalid shortcut! Current shortcut: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3667"/>
+        <source>New shortcut assigned: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3846"/>
+        <source>Assign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3917"/>
+        <source>PieMenu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuickMenu</name>
+    <message>
+        <location filename="../../InitGui.py" line="366"/>
+        <source>Context</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="370"/>
+        <source>PieMenu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="377"/>
+        <source>ToolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="386"/>
+        <source>Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ToolsTab</name>
+    <message>
+        <location filename="../../InitGui.py" line="2858"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="2862"/>
+        <source>Clear search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="3918"/>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/Resources/translation/update_translation.sh
+++ b/Resources/translation/update_translation.sh
@@ -2,9 +2,9 @@
 
 # --------------------------------------------------------------------------------------------------
 #
-# Update translation files
+# Create, update and release translation files.
 #
-# Supported locales on FreeCAD <2024-01-20, FreeCADGui.supportedLocales(), total=40>:
+# Supported locales on FreeCAD <2024-03-13, FreeCADGui.supportedLocales(), total=43>:
 # 	{'English': 'en', 'Afrikaans': 'af', 'Arabic': 'ar', 'Basque': 'eu', 'Belarusian': 'be',
 # 	'Bulgarian': 'bg', 'Catalan': 'ca', 'Chinese Simplified': 'zh-CN',
 # 	'Chinese Traditional': 'zh-TW', 'Croatian': 'hr', 'Czech': 'cs', 'Dutch': 'nl',
@@ -16,21 +16,36 @@
 # 	'Slovenian': 'sl', 'Spanish': 'es-ES', 'Spanish, Argentina': 'es-AR', 'Swedish': 'sv-SE',
 # 	'Turkish': 'tr', 'Ukrainian': 'uk', 'Valencian': 'val-ES', 'Vietnamese': 'vi'}
 #
-# NOTE: WORKFLOW
-# 0. Install Qt tools
-# 	Debian-based (e.g., Ubuntu): $ sudo apt-get install qttools5-dev-tools pyqt5-dev-tools
-# 	Fedora-based: $ sudo dnf install qt5-linguist qt5-devel
-# 	Arch-based: $ sudo pacman -S qt5-tools python-pyqt5
-# 1. Make the script executable
+# NOTE: PREPARATION
+# - Install Qt tools
+# 	Debian-based (e.g., Ubuntu): $ sudo apt-get install qttools5-dev-tools pyqt6-dev-tools
+# 	Fedora-based: $ sudo dnf install qt6-linguist qt6-devel
+# 	Arch-based: $ sudo pacman -S qt6-tools python-pyqt6
+# - Make the script executable
 # 	$ chmod +x update_translation.sh
-# 2. Execute the script passing the locale code as first parameter
-# 	The script has to be executed within the `resources/translations` directory
-# 	Only update the files you're translating!
-# 	$ ./update_translation.sh es-ES
-# 3. Do the translation via Qt Linguist and use `File>Release`
-# 4. If releasing with the script execute the script passing the locale code
-# 	as first parameter and use '-r' flag next
-# 	$ ./update_translation.sh es-ES -r
+# - The script has to be executed within the `Resources/translations` directory.
+# 	Executing the script with no flags involes the help.
+# 	$ ./update_translation.sh
+#
+# NOTE: WORKFLOW TRANSLATOR (LOCAL)
+# - Execute the script passing the `-u` flag plus locale code as argument
+# 	Only update the file(s) you're translating!
+# 	$ ./update_translation.sh -u es-ES
+# - Do the translation via Qt Linguist and use `File>Release`
+# - If releasing with the script execute it passing the `-r` flag
+# 	plus locale code as argument
+# 	$ ./update_translation.sh -r es-ES
+#
+# NOTE: WORKFLOW MAINTAINER (CROWDIN)
+# - Execute the script passing the '-U' flag
+# 	$ ./update_translation.sh -U
+# - Upload the updated file to Crowdin and wait for translators do their thing ;-)
+# - Once done, download the translated files, copy them to `Resources/translations`
+# 	and release all the files to update the changes
+# 	$ ./update_translation.sh -R
+#
+# The usage of `pylupdate6` is preferred over 'pylupdate5' when extracting text strings from
+# 	Python files. Also using `lupdate` from Qt6 is possible.
 #
 # --------------------------------------------------------------------------------------------------
 
@@ -38,7 +53,8 @@ supported_locales=(
 	"en" "af" "ar" "eu" "be" "bg" "ca" "zh-CN" "zh-TW" "hr"
 	"cs" "nl" "fil" "fi" "fr" "gl" "ka" "de" "el" "hu"
 	"id" "it" "ja" "kab" "ko" "lt" "no" "pl" "pt-PT" "pt-BR"
-	"ro" "ru" "sr" "es-ES" "es-AR" "sv-SE" "tr" "uk" "val-ES" "vi"
+	"ro" "ru" "sr" "sr-CS" "sk" "sl" "es-ES" "es-AR" "sv-SE" "tr"
+	"uk" "val-ES" "vi"
 )
 
 is_locale_supported() {
@@ -51,55 +67,91 @@ is_locale_supported() {
 	return 1
 }
 
-get_strings() {
-	# Get translatable strings from ../../*.py Python files
-	pylupdate5 ../../*.py -ts pyfiles.ts -verbose
-}
-
-delete_files() {
-	# Delete files that are no longer needed
-	rm pyfiles.ts
-	rm -f ${WB}.ts
-}
-
-add_new_locale() {
-	echo -e "\033[1;33m\n\t<<< Creating '${WB}_${LOCALE}.ts' file >>>\n\033[m"
-	get_strings
-	# Join strings from Qt Designer and Python files
-	lconvert -source-language en -target-language $LOCALE \
-		-i pyfiles.ts -o ${WB}_${LOCALE}.ts
-}
-
 update_locale() {
-	echo -e "\033[1;32m\n\t<<< Updating '${WB}_${LOCALE}.ts' file >>>\n\033[m"
-	get_strings
-	# Join newly created file with older file ( -no-obsolete)
-	lconvert -source-language en -target-language $LOCALE \
-		-i pyfiles.ts ${WB}_${LOCALE}.ts -o ${WB}_${LOCALE}.ts -no-obsolete
+	local locale="$1"
+	local u=${locale:+_} # Conditional underscore
+
+	# Get translatable strings from Python file(s)
+	# pylupdate5 -verbose ../../InitGui.py -ts pyfiles.ts
+	pylupdate6 ../../*.py -ts _${WB}.ts
+
+	# NOTE: Execute the right commands depending on:
+	# - if the file already exists and
+	# - if it's a locale file or the main, agnostic one
+	if [ ! -f "${WB}${u}${locale}.ts" ]; then
+		if [ "$locale" == "" ]; then
+			lconvert -i _${WB}.ts -o ${WB}.ts
+		else
+			lconvert -source-language en -target-language $locale \
+				-i _${WB}.ts -o ${WB}_${locale}.ts
+		fi
+		echo -e "\033[1;34m\n\t<<< '${WB}${u}${locale}.ts' file created >>>\n\033[m"
+	else
+		if [ "$locale" == "" ]; then
+			lconvert -i _${WB}.ts ${WB}.ts -o ${WB}.ts
+		else
+			lconvert -source-language en -target-language $locale \
+				-i _${WB}.ts ${WB}_${locale}.ts -o ${WB}_${locale}.ts
+		fi
+		echo -e "\033[1;34m\n\t<<< '${WB}${u}${locale}.ts' file updated >>>\n\033[m"
+	fi
+
+	# Delete files that are no longer needed
+	rm -f _${WB}.ts
 }
 
-release_translation() {
-	# Release translation (creation of *.qm file from *.ts file)
-	lrelease ${WB}_${LOCALE}.ts
+release_locale() {
+	# Release locale (creation of *.qm file from *.ts file)
+	local locale="$1"
+	lrelease ${WB}_${locale}.ts
+}
+
+help() {
+	echo -e "\nDescription:"
+	echo -e "\tCreate, update and release translation files."
+	echo -e "\nUsage:"
+	echo -e "\t./update_translation.sh [-R] [-U] [-r <locale>] [-u <locale>]"
+	echo -e "\nFlags:"
+	echo -e "  -R\n\tRelease all locales"
+	echo -e "  -U\n\tUpdate main translation file (locale agnostic)"
+	echo -e "  -r <locale>\n\tRelease the specified locale"
+	echo -e "  -u <locale>\n\tUpdate strings for the specified locale"
 }
 
 # Main function ------------------------------------------------------------------------------------
 
 WB="PieMenu"
-LOCALE="$1"
 
-if is_locale_supported "$LOCALE"; then
-	if [ "$2" == "-r" ]; then
-		release_translation
+if [ $# -eq 0 ]; then
+	help
+elif [ $# -eq 1 ]; then
+	if [ "$1" == "-R" ]; then
+		find . -type f -name '*_*.ts' | while IFS= read -r file; do
+			# Release all locales
+			lrelease $file
+			echo
+		done
+	elif [ "$1" == "-U" ]; then
+		# Update main file (agnostic)
+		update_locale
 	else
-		if [ ! -f "${WB}_${LOCALE}.ts" ]; then
-			add_new_locale
-		else
+		help
+	fi
+elif [ $# -eq 2 ]; then
+	LOCALE="$2"
+	if is_locale_supported "$LOCALE"; then
+		if [ "$1" == "-r" ]; then
+			# Release locale
+			release_locale "$LOCALE"
+		elif [ "$1" == "-u" ]; then
+			# Update main & locale files
 			update_locale
+			update_locale "$LOCALE"
 		fi
-		delete_files
+	else
+		echo "Verify your language code. Case sensitive."
+		echo "If it's correct ask a maintainer to add support for your language on FreeCAD."
 	fi
 else
-	echo "Verify your language code. Case sensitive."
-	echo "If it's correct ask a maintainer to add support for your language on FreeCAD."
+	help
 fi


### PR DESCRIPTION
With the new integration to Crowdin a new workflow is needed for maintainer so I made some changes.

- Enhance description of workflow
- Add missing locales (don't know how I missed them)
- `-U` flag for maintainer to update only main agnostic file
- `-R` flag for maintainer to release all translations
- `-r` & `-u` for translators to do the things they could do before
- Reorganize some functions
- Add help

Also don't forget to upload missing strings to Crowdin in order to be available before new releases :wink: (I think only "Add separator" is missing.

Also #58 could be closed