### PR TITLE
Grubuntu patch 192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # CHANGELOG
+
+### 1.9.2
+- Qt6 fix : pressing the global shortcut no longer opens PieMenu
+- Qt6 fix : modifiers shortcut were broken
+- Qt6 fix : keyValue == False in updateCommands()
+ -Qt6 fix : function onToolListWidget() were broken, setting showquickmenu were broken
+- Qt6 fix : workbenches toolbars were broken
+- Qt6 fix : context mode and setting globalcontext were instable
+- Qt6 fix : add eventfilter to catch "minimize event", remove WA_MacAlwaysShowToolWindow : not supported in the same way in Qt5
+- Fix : setting immediate trigger
+- Fix :problem in createpie (add onpiechange()) to update values after create a new PieMenu
+
 ### 1.9.1
 - Fix window_icon that appears under the dialog window on Linux system
 

--- a/InitGui.py
+++ b/InitGui.py
@@ -31,14 +31,15 @@
 # fix : ajout d'outils ajoute pleins de commandes ! onToolListWidget : if i.checkState() == QtCore.Qt.Checked:
 # fix : toolbars : getGuiToolButtonData( : recuperer la version de qt comme variable globale ??
 # fix : setting showquickmenu is broken : checkboxQuickMenu.checkState() == QtCore.Qt.Checked
+# fix problem in createpie (add onpiechange())
+# fix : context mode à corriger
+# fix : probleme de mise ajour du parmaetre immediate trigger
 #
-#
-#
+# fix : setting globalcontext comportement bizarre !
+
 # TO DO :
-# context mode à corriger
-# à tester sous Mac et Linux : self.menu.setAttribute(QtCore.Qt.WA_MacAlwaysShowToolWindow)
-#  probleme de mise ajour du parmaetre immediate trigger
-# setting globalcontext comportement bizarre !
+
+# à tester sous Mac et Linux :self.menu.setAttribute(QtCore.Qt.WA_MacAlwaysShowToolWindow)
 #
 
 
@@ -2942,6 +2943,8 @@ def pieMenuStart():
 
             createNestedPieMenus()
             reloadWorkbench()
+            ### fix https://github.com/Grubuntu/PieMenu/issues/102
+            onPieChange()
 
         return paramIndexGet.GetGroup(indexNumber)
 
@@ -3103,12 +3106,15 @@ def pieMenuStart():
 
     def copyIndexParams(grpOrg, grpCopy):
         """ Copy value in parameters """
+        #### TO DO : ajouter les paramètres manquants !
         valButOrg = grpOrg.GetInt("Button")
         valRadOrg = grpOrg.GetInt("Radius")
+        valShapeOrg = grpOrg.GetString("Shape")
         tbOrg = grpOrg.GetString("ToolList")
         grpCopy.SetInt("Button", valButOrg)
         grpCopy.SetInt("Radius", valRadOrg)
         grpCopy.SetString("ToolList", tbOrg)
+        grpCopy.SetString("Shape", valShapeOrg)
 
 
     def copyContextParams(grpOrg, grpCopy):

--- a/InitGui.py
+++ b/InitGui.py
@@ -25,9 +25,26 @@
 # http://forum.freecadweb.org/
 # http://www.freecadweb.org/wiki/index.php?title=Code_snippets
 #
+# Qt6 adaptation : a tester aussi sur Qt5
+# fix : modifiers de raccourcis
+# fix : keyValue == False in updateCommands()
+# fix : ajout d'outils ajoute pleins de commandes ! onToolListWidget : if i.checkState() == QtCore.Qt.Checked:
+# fix : toolbars : getGuiToolButtonData( : recuperer la version de qt comme variable globale ??
+# fix : setting showquickmenu is broken : checkboxQuickMenu.checkState() == QtCore.Qt.Checked
+#
+#
+#
+# TO DO :
+# context mode à corriger
+# à tester sous Mac et Linux : self.menu.setAttribute(QtCore.Qt.WA_MacAlwaysShowToolWindow)
+#  probleme de mise ajour du parmaetre immediate trigger
+# setting globalcontext comportement bizarre !
+#
+
+
 
 global PIE_MENU_VERSION
-PIE_MENU_VERSION = "1.9.1"
+PIE_MENU_VERSION = "1.9.2"
 
 def pieMenuStart():
     """Main function that starts the Pie Menu."""
@@ -82,7 +99,7 @@ def pieMenuStart():
     flagShortcutOverride = False
     firstLoad = True
 
-    selectionTriggered = False
+    # selectionTriggered = False
     contextPhase = False
 
     paramPath = "User parameter:BaseApp/PieMenu"
@@ -234,16 +251,31 @@ def pieMenuStart():
             shortcutsAssigned = getAssignedShortcut()
             compareAndDisplayWarning(shortcutsAssigned, currentShortcut)
 
+
         def get_modifier_text(self, modifiers):
+            # Dictionnaire des modificateurs
             modifier_names = {
                 Qt.ControlModifier: 'CTRL',
                 Qt.AltModifier: 'ALT',
                 Qt.ShiftModifier: 'SHIFT',
-                Qt.MetaModifier: 'META',
-                Qt.Key_Tab: 'TAB'
+                Qt.MetaModifier: 'META'
             }
-            modifier_text = '+'.join([modifier_names[modifier] \
-                for modifier in modifier_names if modifiers & modifier])
+
+            # Si aucun modificateur n'est présent, retourner une chaîne vide
+            if modifiers == Qt.KeyboardModifier.NoModifier:
+                return ""
+
+            # Construction du texte pour les modificateurs actifs
+            modifier_text = '+'.join(
+                modifier_names[modifier]
+                for modifier in modifier_names
+                if modifiers & modifier
+            )
+
+            # Gestion de Qt.Key_Tab si nécessaire
+            if modifiers == Qt.Key_Tab:
+                modifier_text += '+TAB' if modifier_text else 'TAB'
+
             return modifier_text
 
 
@@ -391,7 +423,7 @@ def pieMenuStart():
 
         def Activated(self):
             """Run the following code when the command is activated (button press)."""
-            PieMenuInstance.showAtMouse(self.keyValue, notKeyTriggered=False)
+            PieMenuInstance.showAtMouse(self.keyValue)
 
         def IsActive(self):
             """Return True when the command should be active or False when it should be disabled (greyed)."""
@@ -439,7 +471,9 @@ def pieMenuStart():
             self.menu.setObjectName("styleContainer")
             self.menu.setStyleSheet(styleCurrentTheme)
             # QtCore.Qt.WA_MacAlwaysShowToolWindow : needed to hide widget when FreeCad is minimized
-            self.menu.setWindowFlags(QtCore.Qt.FramelessWindowHint | Qt.NoDropShadowWindowHint | QtCore.Qt.WA_MacAlwaysShowToolWindow)
+            # self.menu.setWindowFlags(QtCore.Qt.FramelessWindowHint | Qt.NoDropShadowWindowHint | QtCore.Qt.WA_MacAlwaysShowToolWindow)
+            self.menu.setWindowFlags(QtCore.Qt.FramelessWindowHint | Qt.NoDropShadowWindowHint)
+            self.menu.setAttribute(QtCore.Qt.WA_MacAlwaysShowToolWindow)
             self.menu.setAttribute(QtCore.Qt.WA_TranslucentBackground)
 
             if compositingManager:
@@ -1304,7 +1338,8 @@ def pieMenuStart():
                     num = num + 1
 
             buttonQuickMenu = quickMenu()
-            if checkboxQuickMenu.checkState():
+            # if checkboxQuickMenu.checkState() == QtCore.Qt.Checked:
+            if checkboxQuickMenu.isChecked():
                 buttonQuickMenu.setParent(self.menu)
                 self.buttons.append(buttonQuickMenu)
             else:
@@ -1434,23 +1469,26 @@ def pieMenuStart():
             self.menu.hide()
 
 
-        def showAtMouseInstance(self, keyValue=None, notKeyTriggered=False):
-            nonlocal selectionTriggered
+        def showAtMouseInstance(self, keyValue=None):
             nonlocal contextPhase
-
             enableContext = paramGet.GetBool("EnableContext")
 
-            if contextPhase and keyValue is None:
-                sel = Gui.Selection.getSelectionEx()
-                if not sel:
-                    self.hide()
-                    contextPhase = False
-                    updateCommands()
-                elif not enableContext:
-                    self.hide()
-                    updateCommands()
-                else:
-                    updateCommands(keyValue, context=True)
+            if contextPhase:
+                if keyValue == False or keyValue is None:
+                    sel = Gui.Selection.getSelectionEx()
+                    if not sel:
+                        self.hide()
+                        contextPhase = False
+                        updateCommands()
+                    elif not enableContext:
+                        self.hide()
+                        updateCommands()
+                    else:
+                        try:
+                            keyValue = paramGet.GetString("ContextPie").decode("UTF-8")
+                        except AttributeError:
+                            keyValue = paramGet.GetString("ContextPie")
+                        updateCommands(keyValue, context=True)
             else:
                 updateCommands(keyValue)
 
@@ -1476,7 +1514,7 @@ def pieMenuStart():
                 self.menu.popup(QtCore.QPoint(pos.x() - self.menuSize / 2, pos.y() - self.menuSize / 2))
 
 
-        def showPiemenuPreview(self, keyValue=None, notKeyTriggered=False):
+        def showPiemenuPreview(self, keyValue=None):
             """ Preview of PieMenu in widgetTable on Preferences Tab """
             # get BackgroundColor value in parameters, if 0 then we have a fresh install
             backgroundColorConfig = paramColorGet.GetUnsigned("BackgroundColor")
@@ -1557,11 +1595,11 @@ def pieMenuStart():
                 self.menu.popup(QtCore.QPoint(posX - self.menuSize / 2, posY - self.menuSize / 2))
 
 
-        def showAtMouse(self, keyValue=None, notKeyTriggered=False):
+        def showAtMouse(self, keyValue=None):
             global flagVisi
 
             if not flagVisi:
-                self.showAtMouseInstance(keyValue, notKeyTriggered)
+                self.showAtMouseInstance(keyValue)
                 flagVisi = False
             else:
                 self.menu.hide()
@@ -1845,7 +1883,7 @@ def pieMenuStart():
             shortcut = QShortcut(QKeySequence(shortcutKey), mw)
             namePie = namePie.split("PieMenu_")[1]
             shortcut.activated.connect(lambda keyValue=namePie: \
-                PieMenuInstance.showAtMouse(keyValue=keyValue, notKeyTriggered=False))
+                PieMenuInstance.showAtMouse(keyValue=keyValue))
             shortcut.setEnabled(True)
         return shortcutList
 
@@ -2107,70 +2145,70 @@ def pieMenuStart():
 
     def listTopo():
         """ Handle conditions to trigger context mode """
-        enableContext = paramGet.GetBool("EnableContext")
-        if enableContext:
-            module = None
-            try:
-                g = Gui.ActiveDocument.getInEdit()
-                module = g.Module
-            except:
-                pass
+        nonlocal contextPhase
+        # enableContext = paramGet.GetBool("EnableContext")
+        # if enableContext:
+        module = None
+        try:
+            g = Gui.ActiveDocument.getInEdit()
+            module = g.Module
+        except:
+            pass
 
-            if module is None or module == "SketcherGui":
-                nonlocal selectionTriggered
-                nonlocal contextPhase
-                sel = Gui.Selection.getSelectionEx()
-                vertexes = 0
-                edges = 0
-                faces = 0
-                objects = 0
-                allList = []
-                for i in sel:
-                    if not i.SubElementNames:
-                        objects = objects + 1
-                    else:
-                        for a in i.SubElementNames:
-                            allList.append(a)
-                for i in allList:
-                    if i.startswith('Vertex') or i.startswith('RootPoint'):
-                        vertexes = vertexes + 1
-                    elif i.startswith('Edge'):
-                        edges = edges + 1
-                    elif i.startswith('Face'):
-                        faces = faces + 1
-                    else:
-                        pass
-                pieIndex = getContextPie(vertexes,
-                                         edges,
-                                         faces,
-                                         objects)
-
-                if pieIndex:
-                    try:
-                        pieName = paramIndexGet.GetString(pieIndex).decode("UTF-8")
-                    except AttributeError:
-                        pieName = paramIndexGet.GetString(pieIndex)
-                    try:
-                        paramGet.SetString("ContextPie", pieName.encode("UTF-8"))
-                    except TypeError:
-                        paramGet.SetString("ContextPie", pieName)
-                    contextPhase = True
-
-                    # updateCommands(keyValue=None, context=True)
-                    PieMenuInstance.hide()
-
-                    activeWB = Gui.activeWorkbench().name()
-                    activeWB = activeWB.split("Workbench")
-                    contextWorkbench = None
-                    contextWorkbench = getParameterGroup(pieName, "String", "ContextWorkbench")
-
-                    if contextWorkbench == activeWB[0] or contextWorkbench is None or contextWorkbench == translate("ContextTab", "All Workbenches"):
-                        immediateTrigger = getParameterGroup(pieName, "Bool", "ImmediateTriggerContext")
-                        if immediateTrigger:
-                            selectionTriggered = True
-                            PieMenuInstance.showAtMouse(notKeyTriggered=True)
+        if module is None or module == "SketcherGui":
+            # nonlocal contextPhase
+            sel = Gui.Selection.getSelectionEx()
+            vertexes = 0
+            edges = 0
+            faces = 0
+            objects = 0
+            allList = []
+            for i in sel:
+                if not i.SubElementNames:
+                    objects = objects + 1
+                else:
+                    for a in i.SubElementNames:
+                        allList.append(a)
+            for i in allList:
+                if i.startswith('Vertex') or i.startswith('RootPoint'):
+                    vertexes = vertexes + 1
+                elif i.startswith('Edge'):
+                    edges = edges + 1
+                elif i.startswith('Face'):
+                    faces = faces + 1
                 else:
                     pass
+            pieIndex = getContextPie(vertexes,
+                                     edges,
+                                     faces,
+                                     objects)
+
+            if pieIndex:
+                try:
+                    pieName = paramIndexGet.GetString(pieIndex).decode("UTF-8")
+                except AttributeError:
+                    pieName = paramIndexGet.GetString(pieIndex)
+                try:
+                    paramGet.SetString("ContextPie", pieName.encode("UTF-8"))
+                except TypeError:
+                    paramGet.SetString("ContextPie", pieName)
+                contextPhase = True
+
+                # updateCommands(keyValue=None, context=True)
+                PieMenuInstance.hide()
+
+                activeWB = Gui.activeWorkbench().name()
+                activeWB = activeWB.split("Workbench")
+                contextWorkbench = None
+                contextWorkbench = getParameterGroup(pieName, "String", "ContextWorkbench")
+
+                if contextWorkbench == activeWB[0] or contextWorkbench is None or contextWorkbench == translate("ContextTab", "All Workbenches"):
+                    immediateTrigger = getParameterGroup(pieName, "Bool", "ImmediateTriggerContext")
+                    if immediateTrigger:
+                        PieMenuInstance.showAtMouse()
+            else:
+                contextPhase = False
+        return contextPhase
 
 
     def addObserver():
@@ -2249,9 +2287,20 @@ def pieMenuStart():
 
     def getGuiToolButtonData(idToolBar, actions, commands, workbenches):
         actionMapAll = getGuiActionMapAll()
+
+        qt_version = QtCore.qVersion()
+        qt_major_version = int(qt_version.split('.')[0])
+
         for i in actionMapAll:
             action = actionMapAll[i]
-            for widgets in action.associatedWidgets():
+            
+            if qt_major_version >= 6:
+                # for Qt6
+                associated_items = action.associatedObjects()
+            else:
+                # for Qt5
+                associated_items = action.associatedWidgets()
+            for widgets in associated_items:
                 if widgets.windowTitle() == idToolBar:
                     getActionData(action, actions, commands, workbenches)
 
@@ -2278,14 +2327,13 @@ def pieMenuStart():
 
 
     def updateCommands(keyValue=None, context=False):
-                                  
         # keyValue = None > Global shortcut
         # keyValue != None > Custom shortcut
         global triggerMode
         global hoverDelay
         global loadedWorkbenches
 
-        if keyValue is None:
+        if keyValue is None or keyValue == False:
             # context
             if context:
                 try:
@@ -2582,7 +2630,7 @@ def pieMenuStart():
         buttonListWidget.blockSignals(False)
 
         showPiemenu.hide()
-        PieMenuInstance.showPiemenuPreview(keyValue=cBox.currentText(), notKeyTriggered=False)
+        PieMenuInstance.showPiemenuPreview(keyValue=cBox.currentText())
         showPiemenu.show()
 
 
@@ -3269,7 +3317,7 @@ def pieMenuStart():
             if key == "toolBarTab":
                 PieMenuInstance.showPiemenuPreview("toolBarTab")
             else:
-                PieMenuInstance.showPiemenuPreview(keyValue=cBox.currentText(), notKeyTriggered=False)
+                PieMenuInstance.showPiemenuPreview(keyValue=cBox.currentText())
             showPiemenu.show()
         except:
             None
@@ -3563,7 +3611,7 @@ def pieMenuStart():
 
     def onShowQuickMenu(state):
         """ Set visibility of Quickmenu """
-        if state == Qt.Checked:
+        if state == 2:
             paramGet.SetBool("ShowQuickMenu", True)
         else:
             paramGet.SetBool("ShowQuickMenu", False)
@@ -3572,7 +3620,7 @@ def pieMenuStart():
 
     def onRightClickTrigger(state):
         """ Set right click trigger """
-        if state == Qt.Checked:
+        if state == 2:
             paramGet.SetBool("RightClickTrigger", True)
             spinDelayRightClick.setEnabled(True)
         else:
@@ -3582,7 +3630,7 @@ def pieMenuStart():
 
     def onContext(state):
         """ Set context mode activation """
-        if state == Qt.Checked:
+        if state == 2:
             paramGet.SetBool("EnableContext", True)
         else:
             paramGet.SetBool("EnableContext", False)
@@ -3685,7 +3733,6 @@ def pieMenuStart():
         """ Handle list of tool in tool list widget """
         text = cBox.currentText()
         items = []
-
         for index in range(toolListWidget.count()):
             items.append(toolListWidget.item(index))
 
@@ -3693,7 +3740,7 @@ def pieMenuStart():
         checkListOff = []
 
         for i in items:
-            if i.checkState():
+            if i.checkState() == QtCore.Qt.Checked:
                 checkListOn.append(i.data(QtCore.Qt.UserRole))
             else:
                 checkListOff.append(i.data(QtCore.Qt.UserRole))
@@ -3720,7 +3767,6 @@ def pieMenuStart():
         for i in checkListOn:
             if i not in toolList:
                 toolList.append(i)
-
             else:
                 pass
 
@@ -3729,6 +3775,7 @@ def pieMenuStart():
                 toolList.remove(i)
             else:
                 pass
+
         for i in indexList:
             a = str(i)
             try:
@@ -3737,7 +3784,7 @@ def pieMenuStart():
                 pie = paramIndexGet.GetString(a)
             if pie == text:
                 group = paramIndexGet.GetGroup(a)
-                toolList = group.SetString("ToolList", ".,.".join(toolList))
+                group.SetString("ToolList", ".,.".join(toolList))
             else:
                 pass
         buttonList()
@@ -3985,7 +4032,7 @@ def pieMenuStart():
                 msg.setText(translate("GlobalSettingsTab", "PieMenu settings exported successfully."))
                 msg.setWindowTitle(translate("GlobalSettingsTab", "Information"))
                 msg.setStandardButtons(QMessageBox.Ok)
-                msg.exec_()
+                msg.exec()
 
             except Exception as e:
                 print(f"Error exporting settings: {str(e)}")
@@ -4008,7 +4055,7 @@ def pieMenuStart():
         msg.setWindowTitle(translate("GlobalSettingsTab", "Backup user settings"))
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         msg.setDefaultButton(QMessageBox.Yes)
-        response = msg.exec_()
+        response = msg.exec()
 
         if response == QMessageBox.Yes:
             if not os.path.exists(backupDir):
@@ -4023,7 +4070,7 @@ def pieMenuStart():
                 msg.setInformativeText(translate("GlobalSettingsTab", "Click OK to select the file to import PieMenu settings."))
                 msg.setWindowTitle(translate("GlobalSettingsTab", "Successful backup"))
                 msg.setStandardButtons(QMessageBox.Ok)
-                msg.exec_()
+                msg.exec()
 
                 file, _ = QFileDialog.getOpenFileName(None, translate("ImportSettingsWindow", "Import PieMenu settings from a file"), "" , "XML (*.FCParam)")
 
@@ -4043,7 +4090,7 @@ def pieMenuStart():
                         nowButton.setText(translate("RestartFreeCADWindow","Now"))
                         laterButton = msg.button(QMessageBox.No)
                         laterButton.setText(translate("RestartFreeCADWindow","Later"))
-                        response = msg.exec_()
+                        response = msg.exec()
 
                         if response == QMessageBox.Yes:
                             """Shuts down and restarts FreeCAD"""
@@ -4504,7 +4551,7 @@ def pieMenuStart():
                 text = pieGroup.checkedAction().text()
                 paramGet.SetString("CurrentPie", text)
             PieMenuInstance.hide()
-            PieMenuInstance.showAtMouse(notKeyTriggered=True)
+            PieMenuInstance.showAtMouse()
 
 
         def onMenuToolBar():
@@ -4591,7 +4638,7 @@ def pieMenuStart():
                 toolbar_desc = toolbar_desc + ': ' + sender.data()
                 paramGet.SetString("ToolBar", toolbar_desc)
                 PieMenuInstance.hide()
-                PieMenuInstance.showAtMouse(notKeyTriggered=True)
+                PieMenuInstance.showAtMouse()
 
 
         def onPrefButton():

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>PieMenu</name>
   <description>The PieMenu module is a tool to accelerate and simplify your workflow in usage of FreeCAD.</description>
-  <version>1.9.1</version>
-  <date>2024-11-01</date>
+  <version>1.9.2</version>
+  <date>2024-11-08</date>
   <maintainer>Grubuntu</maintainer>
   <license file="LICENSE">LGPL-2.1-or-later</license>
   <url type="repository" branch="master">https://github.com/Grubuntu/PieMenu</url>


### PR DESCRIPTION
Qt6 fix : pressing the global shortcut no longer opens PieMenu
Qt6 fix : modifiers shortcut were broken
Qt6 fix : keyValue == False in updateCommands() -Qt6 fix : function onToolListWidget() were broken, setting showquickmenu were broken
Qt6 fix : workbenches toolbars were broken
Qt6 fix : context mode and setting globalcontext were instable
Qt6 fix : add eventfilter to catch "minimize event", remove WA_MacAlwaysShowToolWindow : not supported in the same way in Qt5
Fix : setting immediate trigger
Fix :problem in createpie (add onpiechange()) to update values after create a new PieMenu