### PR TITLE
Circular central button is not circular with Opentheme 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Fix [#109] : circular central button was not circular with the Opentheme theme
   
 ### 1.9.4
-Fix [#106] : FreeCAD crash when we quit Sketcher with PieMenu validation button and 'Sketcher_Dimension'/'Sketcher_CompDimensionTools' is active
+- Fix [#106] : FreeCAD crash when we quit Sketcher with PieMenu validation button and 'Sketcher_Dimension'/'Sketcher_CompDimensionTools' is active
 Added ability to move or delete severals command at the same time in list tools : [#105](https://github.com/Grubuntu/PieMenu/issues/105)
 
 ### 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+### 1.9.5
+- Fix [#109] : circular central button was not circular with the Opentheme theme
+  
 ### 1.9.4
 Fix [#106] : FreeCAD crash when we quit Sketcher with PieMenu validation button and 'Sketcher_Dimension'/'Sketcher_CompDimensionTools' is active
 Added ability to move or delete severals command at the same time in list tools : [#105](https://github.com/Grubuntu/PieMenu/issues/105)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 ### 1.9.5
-- Fix [#109] : circular central button was not circular with the Opentheme theme
+- Fix https://github.com/Grubuntu/PieMenu/issues/109 : circular central button was not circular with the Opentheme theme
   
 ### 1.9.4
 - Fix [#106] : FreeCAD crash when we quit Sketcher with PieMenu validation button and 'Sketcher_Dimension'/'Sketcher_CompDimensionTools' is active

--- a/Resources/Stylesheets/Accents.qss
+++ b/Resources/Stylesheets/Accents.qss
@@ -1,6 +1,8 @@
 /* PieMenu widget stylesheet for FreeCAD */
 /* Copyright (C) 2024 Pgilfernandez @ FreeCAD */
 
+/* Reset CSS Values*/
+* {margin:0;}
 
 /* ====================================================== */
 /*                 Normal pie button style                */

--- a/Resources/Stylesheets/Dark behave.qss
+++ b/Resources/Stylesheets/Dark behave.qss
@@ -1,6 +1,8 @@
 /* PieMenu widget stylesheet for FreeCAD */
 /* Copyright (C) 2024 Pgilfernandez @ FreeCAD */
 
+/* Reset CSS Values*/
+* {margin:0;}
 
 /* ====================================================== */
 /*                 Normal pie button style                */
@@ -80,7 +82,7 @@ QToolButton#styleMenuClose::menu-indicator {
 /* Used for fillet/chamfer fast radius setting (and probably others) */
 
 QComboBox#styleCombo {
-    background-color: transparent   ;
+    background-color: transparent;
     border: 1px solid transparent;
 }
 

--- a/Resources/Stylesheets/Dark.qss
+++ b/Resources/Stylesheets/Dark.qss
@@ -1,6 +1,8 @@
 /* PieMenu widget stylesheet for FreeCAD */
 /* Copyright (C) 2024 Pgilfernandez @ FreeCAD */
 
+/* Reset CSS Values*/
+* {margin:0;}
 
 /* ====================================================== */
 /*                 Normal pie button style                */
@@ -68,7 +70,7 @@ QToolButton#styleMenuClose::menu-indicator {
 /* Used for fillet/chamfer fast radius setting (and probably others) */
 
 QComboBox#styleCombo {
-    background-color: transparent   ;
+    background-color: transparent;
     border: 1px solid transparent;
 }
 

--- a/Resources/Stylesheets/Legacy.qss
+++ b/Resources/Stylesheets/Legacy.qss
@@ -1,6 +1,8 @@
 /* PieMenu widget stylesheet for FreeCAD */
 /* Copyright (C) 2024 Pgilfernandez @ FreeCAD */
 
+/* Reset CSS Values*/
+* {margin:0;}
 
 /* ====================================================== */
 /*                 Normal pie button style                */
@@ -79,7 +81,7 @@ QToolButton#styleMenuClose::menu-indicator {
 /* Used for fillet/chamfer fast radius setting (and probably others) */
 
 QComboBox#styleCombo {
-    background-color: transparent   ;
+    background-color: transparent;
     border: 1px solid transparent;
 }
 

--- a/Resources/Stylesheets/Light.qss
+++ b/Resources/Stylesheets/Light.qss
@@ -1,6 +1,8 @@
 /* PieMenu widget stylesheet for FreeCAD */
 /* Copyright (C) 2024 Pgilfernandez @ FreeCAD */
 
+/* Reset CSS Values*/
+* {margin:0;}
 
 /* ====================================================== */
 /*                 Normal pie button style                */
@@ -67,7 +69,7 @@ QToolButton#styleMenuClose::menu-indicator {
 /* Used for fillet/chamfer fast radius setting (and probably others) */
 
 QComboBox#styleCombo {
-    background-color: transparent   ;
+    background-color: transparent;
     border: 1px solid transparent;
 }
 

--- a/Resources/Stylesheets/Transparent.qss
+++ b/Resources/Stylesheets/Transparent.qss
@@ -1,6 +1,8 @@
 /* PieMenu widget stylesheet for FreeCAD */
 /* Copyright (C) 2024 Pgilfernandez @ FreeCAD */
 
+/* Reset CSS Values*/
+* {margin:0;}
 
 /* ====================================================== */
 /*                 Normal pie button style                */
@@ -68,7 +70,7 @@ QToolButton#styleMenuClose::menu-indicator {
 /* Used for fillet/chamfer fast radius setting (and probably others) */
 
 QComboBox#styleCombo {
-    background-color: transparent   ;
+    background-color: transparent;
     border: 1px solid transparent;
 }
 

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>PieMenu</name>
   <description>The PieMenu module is a tool to accelerate and simplify your workflow in usage of FreeCAD.</description>
-  <version>1.9.4</version>
-  <date>2024-11-11</date>
+  <version>1.9.5</version>
+  <date>2024-11-12</date>
   <maintainer>Grubuntu</maintainer>
   <license file="LICENSE">LGPL-2.1-or-later</license>
   <url type="repository" branch="master">https://github.com/Grubuntu/PieMenu</url>


### PR DESCRIPTION
Fix https://github.com/Grubuntu/PieMenu/issues/109 : the circular central button is not circular with the Opentheme theme 