### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## 1.10.1
+- Fix user config path and export settings extension (hasecilu)
+- Fix format for translation (hasecilu)
+
 ### 1.10
 - Added workbench in toollist 
 - Added ability to sort column tool and workbench column ascending or descending

--- a/InitGui.py
+++ b/InitGui.py
@@ -3977,8 +3977,8 @@ def pieMenuStart():
 
 
     def onParamImport():
-        """ Import parameter from a file """
-        configDir = App.getUserAppDataDir()
+        """Import parameter from a file"""
+        configDir = App.getUserConfigDir()
         configDir = configDir.replace("\\", "/")
         userConfigFile = os.path.join(configDir, "user.cfg")
 

--- a/InitGui.py
+++ b/InitGui.py
@@ -4004,8 +4004,18 @@ def pieMenuStart():
                 print(f"Backup of configuration file created at {backupFile}")
                 msg = QMessageBox()
                 msg.setIcon(QMessageBox.Information)
-                msg.setText(translate("GlobalSettingsTab", f"Backup of the current user configuration file successfully saved in: {backupFile}" ))
-                msg.setInformativeText(translate("GlobalSettingsTab", "Click OK to select the file to import PieMenu settings."))
+                msg.setText(
+                    translate(
+                        "GlobalSettingsTab",
+                        "Backup of the current user configuration file successfully saved in: {}",
+                    ).format(backupFile)
+                )
+                msg.setInformativeText(
+                    translate(
+                        "GlobalSettingsTab",
+                        "Click OK to select the file to import PieMenu settings.",
+                    )
+                )
                 msg.setWindowTitle(translate("GlobalSettingsTab", "Successful backup"))
                 msg.setStandardButtons(QMessageBox.Ok)
                 msg.exec()

--- a/InitGui.py
+++ b/InitGui.py
@@ -27,7 +27,7 @@
 #
 
 global PIE_MENU_VERSION
-PIE_MENU_VERSION = "1.10"
+PIE_MENU_VERSION = "1.10.1"
 
 def pieMenuStart():
     """Main function that starts the Pie Menu."""

--- a/InitGui.py
+++ b/InitGui.py
@@ -3960,6 +3960,8 @@ def pieMenuStart():
         file, _ = QFileDialog.getSaveFileName(None, translate("ExportSettingsWindow", "Export PieMenu settings to a file"), "" , "XML (*.FCParam)")
         if file:
             try:
+                if not file.endswith(".FCParam"):
+                    file += ".FCParam"
                 item = App.ParamGet("User parameter:BaseApp/PieMenu")
                 item.Export(file)
 

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>PieMenu</name>
   <description>The PieMenu module is a tool to accelerate and simplify your workflow in usage of FreeCAD.</description>
-  <version>1.10</version>
-  <date>2024-11-22</date>
+  <version>1.10.1</version>
+  <date>2024-11-24</date>
   <maintainer>Grubuntu</maintainer>
   <license file="LICENSE">LGPL-2.1-or-later</license>
   <url type="repository" branch="master">https://github.com/Grubuntu/PieMenu</url>


### PR DESCRIPTION
- Include .FCparam extension when exporting settings
- Fix config directory on Linux. Previously config file was expected on `~/.local/share/FreeCAD` dir but that file is on `~/.config/FreeCAD/` directory, now I'm using `$XDG_CONFIG_HOME` environment variable to get the config dir, defaulting on `~/.config/FreeCAD/` **BUT FIX WILL NOT WORK ON WINDOWS OR MAC!** Maybe FreeCAD should have it's own config method.
- Replace f-string with .format() to make translation work on dialog, (needs an update of translations file but there is no hurry)